### PR TITLE
Improve text customization on the cardview for localisation

### DIFF
--- a/src/CardView.js
+++ b/src/CardView.js
@@ -86,6 +86,7 @@ export default class CardView extends Component {
     expiry: PropTypes.string,
     cvc: PropTypes.string,
     placeholder: PropTypes.object,
+    expiryLabel: PropTypes.string,
 
     scale: PropTypes.number,
     fontFamily: PropTypes.string,
@@ -102,7 +103,7 @@ export default class CardView extends Component {
       expiry: "••/••",
       cvc: "•••",
     },
-
+    expiryLabel: "MONTH/YEAR",
     scale: 1,
     fontFamily: Platform.select({ ios: "Courier", android: "monospace" }),
     imageFront: require("../images/card-front.png"),
@@ -112,7 +113,7 @@ export default class CardView extends Component {
   render() {
     const { focused,
       brand, name, number, expiry, cvc, customIcons,
-      placeholder, imageFront, imageBack, scale, fontFamily } = this.props;
+      placeholder, imageFront, imageBack, scale, fontFamily, expiryLabel } = this.props;
 
     const Icons = { ...defaultIcons, ...customIcons };
     const isAmex = brand === "american-express";
@@ -145,7 +146,7 @@ export default class CardView extends Component {
                 { !name ? placeholder.name : name.toUpperCase() }
               </Text>
               <Text style={[s.baseText, { fontFamily }, s.expiryLabel, s.placeholder, focused === "expiry" && s.focused]}>
-                MONTH/YEAR
+                {expiryLabel}
               </Text>
               <Text style={[s.baseText, { fontFamily }, s.expiry, !expiry && s.placeholder, focused === "expiry" && s.focused]}>
                 { !expiry ? placeholder.expiry : expiry }

--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -61,6 +61,8 @@ export default class CreditCardInput extends Component {
     cardScale: PropTypes.number,
     cardFontFamily: PropTypes.string,
     cardBrandIcons: PropTypes.object,
+    cardExpiryLabel: PropTypes.string,
+    cardPlaceholders: PropTypes.object,
 
     allowScroll: PropTypes.bool,
 
@@ -87,6 +89,8 @@ export default class CreditCardInput extends Component {
       borderBottomWidth: 1,
       borderBottomColor: "black",
     },
+    cardExpiryLabel: CreditCard.defaultProps.expiryLabel,
+    cardPlaceholders: CreditCard.defaultProps.placeholder,
     validColor: "",
     invalidColor: "red",
     placeholderColor: "gray",
@@ -144,7 +148,8 @@ export default class CreditCardInput extends Component {
       cardImageFront, cardImageBack, inputContainerStyle,
       values: { number, expiry, cvc, name, type }, focused,
       allowScroll, requiresName, requiresCVC, requiresPostalCode,
-      cardScale, cardFontFamily, cardBrandIcons,
+      cardScale, cardFontFamily, cardBrandIcons,cardExpiryLabel,
+      cardPlaceholders
     } = this.props;
 
     return (
@@ -159,7 +164,12 @@ export default class CreditCardInput extends Component {
           name={requiresName ? name : " "}
           number={number}
           expiry={expiry}
-          cvc={cvc} />
+          cvc={cvc}
+          expiryLabel={cardExpiryLabel}
+          placeholder={{
+            ...CreditCard.defaultProps.placeholder,
+            ...cardPlaceholders
+          }}/>
         <ScrollView ref="Form"
           horizontal
           keyboardShouldPersistTaps="always"


### PR DESCRIPTION
Add a field expiryLabel for the card expiry date label
Allow the card placeholders to be customised
- Merge the placeholder defaults with the provided props 
  Instead of replacing, this should allow for individual customization of fields